### PR TITLE
BUG: Mouse interaction on blocks is still "allowed" even after escape is pressed.

### DIFF
--- a/client/src/Player.cpp
+++ b/client/src/Player.cpp
@@ -52,7 +52,7 @@ void Player::onMouseClick(TVector2<int> position, events::MouseAction action, ev
 		return pos.x > 0.f && pos.y > 0.f && pos.z > 0.f;
 	};
 
-	if (action == MouseAction::DOWN && m_camera->enabled == true)
+	if (action == MouseAction::DOWN && m_camera->enabled)
 	{
 		Vector3 pos = playerCoordsToBlockCoords(m_camera->getPosition());
 


### PR DESCRIPTION
Changed branch name to fit naming conventions and shortened the fix code.