### PR TITLE
Fix block UVs

### DIFF
--- a/engine/src/voxels/Chunk.cpp
+++ b/engine/src/voxels/Chunk.cpp
@@ -8,7 +8,15 @@ using namespace phx::voxels;
 using namespace phx;
 
 static const Vector2 CubeUV[] = {
-	// front
+	// front north
+	Vector2(-0.f, 1.f),
+	Vector2(-1.f, 1.f),
+	Vector2(-1.f, 0.f),
+	Vector2(-1.f, 0.f),
+	Vector2(-0.f, 0.f),
+	Vector2(-0.f, 1.f),
+
+	// back south
 	Vector2(0.f, 1.f),
 	Vector2(1.f, 1.f),
 	Vector2(1.f, 0.f),
@@ -16,23 +24,15 @@ static const Vector2 CubeUV[] = {
 	Vector2(0.f, 0.f),
 	Vector2(0.f, 1.f),
 
-	// back
-	Vector2(0.f, 1.f),
-	Vector2(1.f, 1.f),
-	Vector2(1.f, 0.f),
-	Vector2(1.f, 0.f),
-	Vector2(0.f, 0.f),
-	Vector2(0.f, 1.f),
+	// left west
+	Vector2(-0.f, 0.f),
+	Vector2(-1.f, 0.f),
+	Vector2(-1.f, 1.f),
+	Vector2(-1.f, 1.f),
+	Vector2(-0.f, 1.f),
+	Vector2(-0.f, 0.f),
 
-	// left
-	Vector2(0.f, 0.f),
-	Vector2(1.f, 0.f),
-	Vector2(1.f, 1.f),
-	Vector2(1.f, 1.f),
-	Vector2(0.f, 1.f),
-	Vector2(0.f, 0.f),
-
-	// right
+	// right east
 	Vector2(0.f, 0.f),
 	Vector2(1.f, 0.f),
 	Vector2(1.f, 1.f),
@@ -49,12 +49,12 @@ static const Vector2 CubeUV[] = {
 	Vector2(0.f, 1.f),
 
 	// top
-	Vector2(0.f, 1.f),
-	Vector2(1.f, 1.f),
-	Vector2(1.f, 0.f),
-	Vector2(1.f, 0.f),
-	Vector2(0.f, 0.f),
-	Vector2(0.f, 1.f),
+	Vector2(0.f, -1.f),
+	Vector2(1.f, -1.f),
+	Vector2(1.f, -0.f),
+	Vector2(1.f, -0.f),
+	Vector2(0.f, -0.f),
+	Vector2(0.f, -1.f),
 };
 
 static const Vector3 CubeVerts[] = {


### PR DESCRIPTION
Should fix #45
Front of the blocks faces north instead of the right block side as shown in my explanation image in #45.
New uv data visualization.
![image](https://user-images.githubusercontent.com/16853304/50196644-34341a00-0344-11e9-8a1c-6d0a1d7c1d68.png)
I fixed the front, left, and top UVs.