### PR TITLE
Basic Multithreading in the Chunking code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,8 @@
 # Build folders
 build/*
 BUILD/*
-**/COMPILE/bin
-**/COMPILE/lib
-**/docs/html
+Build/*
+**/Quartz/Documentation/html
 **/cmake-build-debug
 
 # CLion

--- a/Quartz/Documentation/Doxyfile
+++ b/Quartz/Documentation/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = 0.1.0
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "The Documentation for a the Quartz game engine"
+PROJECT_BRIEF          = "The Documentation for Quartz Engine"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -171,7 +171,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = ../source/include
+STRIP_FROM_INC_PATH    = ../Engine/Include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../source/
+INPUT                  = ../Engine/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/Quartz/Engine/Include/Quartz/Core/Platform/GLWindow.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Platform/GLWindow.hpp
@@ -28,7 +28,6 @@
 #include <Quartz/Core/Events/Event.hpp>
 #include <Quartz/Core/Graphics/IWindow.hpp>
 
-#include <vector>
 #include <functional>
 
 #define SDL_MAIN_HANDLED

--- a/Quartz/Engine/Include/Quartz/Core/Platform/SDLGuiLayer.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Platform/SDLGuiLayer.hpp
@@ -23,13 +23,15 @@
 
 #pragma once
 
+#include <Quartz/Core/Core.hpp>
+
 #include <SDL.h>
 
 namespace qz
 {
 	namespace gfx
 	{
-		class SDLGuiLayer
+		class QZ_API SDLGuiLayer
 		{
 		public:
 			void init(SDL_Window* window, SDL_GLContext* context);
@@ -40,8 +42,8 @@ namespace qz
 			void pollEvents(SDL_Event* event);
 
 		private:
-			SDL_Window* m_window;
-			SDL_GLContext* m_context;
+			SDL_Window* m_window = nullptr;
+			SDL_GLContext* m_context = nullptr;
 		};
 	}
 }

--- a/Quartz/Engine/Include/Quartz/Core/Utilities/CMakeLists.txt
+++ b/Quartz/Engine/Include/Quartz/Core/Utilities/CMakeLists.txt
@@ -1,10 +1,12 @@
-set(currentDir ${CMAKE_CURRENT_LIST_DIR})
+add_subdirectory(Threading)
 
+set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(utilityHeaders
+	${threadingHeaders}
+
 	${currentDir}/Logger.hpp
 	${currentDir}/FileIO.hpp
 	${currentDir}/Config.hpp
-	${currentDir}/ThreadPool.hpp
 	
 	PARENT_SCOPE
 )

--- a/Quartz/Engine/Include/Quartz/Core/Utilities/Threading/CMakeLists.txt
+++ b/Quartz/Engine/Include/Quartz/Core/Utilities/Threading/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(currentDir ${CMAKE_CURRENT_LIST_DIR})
+
+set(threadingHeaders
+	${currentDir}/SingleWorker.hpp
+	${currentDir}/ThreadPool.hpp
+	
+	PARENT_SCOPE
+)

--- a/Quartz/Engine/Include/Quartz/Core/Utilities/Threading/ThreadPool.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Utilities/Threading/ThreadPool.hpp
@@ -23,48 +23,43 @@
 
 #pragma once
 
-#include <Quartz/Core/Graphics/API/IStateManager.hpp>
-#include <Quartz/Core/Graphics/API/IBuffer.hpp>
-#include <Quartz/Core/Graphics/API/ITextureArray.hpp>
+#include <Quartz/Core/Core.hpp>
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+#include <deque>
+#include <vector>
+#include <functional>
 
 namespace qz
 {
-	namespace voxels
+	namespace utils
 	{
-		struct ChunkMesh;
-		struct ChunkVert3D
+		namespace threading
 		{
-			qz::Vector3 verts;
-			qz::Vector2 uvs;
+			class QZ_API ThreadPool
+			{
+			public:
+				ThreadPool(const int threadCount);
+				~ThreadPool();
 
-			int texLayer;
+				void addWork(std::function<void()> fun);
 
-			ChunkVert3D(const qz::Vector3& vertices, const qz::Vector2& UVs, const int textureLayer) :
-				verts(vertices), uvs(UVs), texLayer(textureLayer)
-			{}
-		};
+			private:
+				bool m_running;
 
-		class ChunkRenderer
-		{
-		public:
-			ChunkRenderer() = default;
-			~ChunkRenderer() = default;
+				std::mutex m_mutex;
+				std::condition_variable m_condition;
 
-			ChunkRenderer(const ChunkRenderer& other);
-			ChunkRenderer& operator=(const ChunkRenderer& other);
+				std::vector<std::thread> m_threads;
+				std::deque<std::function<void()>> m_scheduledTasks;
 
-			ChunkRenderer(ChunkRenderer&& other) noexcept;
-			ChunkRenderer& operator=(ChunkRenderer&& other) noexcept;
-
-			bool updateMesh(const ChunkMesh& mesh, int* bufferCounter);
-			void render() const;
-
-		private:
-			std::size_t m_verticesToDraw = 0;
-
-			gfx::api::GraphicsResource<gfx::api::IStateManager> m_stateManager = nullptr;
-			gfx::api::GraphicsResource<gfx::api::IBuffer> m_buffer = nullptr;
-			gfx::api::GraphicsResource<gfx::api::ITextureArray> m_textureArray = nullptr;
-		};
+			private:
+				void threadHandle();
+			};
+		}
 	}
 }
+

--- a/Quartz/Engine/Include/Quartz/Voxels/Block.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/Block.hpp
@@ -49,12 +49,14 @@ namespace qz
 		{
 		public:
 			RegistryBlock() = delete;
-			RegistryBlock(std::string blockID, std::string blockName, int initialHP, BlockType blockType);
+			RegistryBlock(const std::string& blockID, const std::string& blockName, int initialHP, BlockType blockType);
 			RegistryBlock(const RegistryBlock& other) = default;
 
 			~RegistryBlock() = default;
 
 			const std::string& getBlockID() const;
+			int getRegistryID() const;
+			
 			const std::string& getBlockName() const;
 			BlockType getBlockType() const;
 
@@ -87,6 +89,10 @@ namespace qz
 			InteractionCallback m_interactRightCallback;
 
 			unsigned int m_initialHealthPoints;
+
+		private:
+			int m_registryID = -1;
+			friend class BlockLibrary;
 		};
 
 		class BlockInstance
@@ -94,16 +100,17 @@ namespace qz
 		public:
 			BlockInstance();
 			BlockInstance(const std::string& blockID);
+			BlockInstance(int registryID);
 
 			~BlockInstance() = default;
 
 			unsigned int getHitpoints() const;
 			void setHitpoints(unsigned int hitpoints);
 
-			const std::string& getBlockName() const;
-			void setBlockName(const std::string& name);
-
 			const std::string& getBlockID() const;
+			int getRegistryID() const;
+
+			const std::string& getBlockName() const;
 			BlockType getBlockType() const;
 
 			const std::vector<std::string>& getBlockTextures() const;
@@ -111,8 +118,7 @@ namespace qz
 		private:
 			unsigned int m_hitpoints;
 
-			std::string m_blockID;
-			std::string m_blockName;
+			int m_registryID;
 			BlockType m_blockType;
 		};
 
@@ -123,8 +129,9 @@ namespace qz
 			
 			void init();
 
-			void registerBlock(const RegistryBlock& block);
+			void registerBlock(RegistryBlock block);
 			
+			const RegistryBlock& requestBlock(int registryID) const;
 			const RegistryBlock& requestBlock(const std::string& blockID) const;
 
 		private:
@@ -135,6 +142,7 @@ namespace qz
 			~BlockLibrary() = default;
 
 			std::unordered_map<std::string, RegistryBlock> m_registeredBlocks;
+			std::vector<std::string> m_registeredBlockAliases;
 		};
 	}
 }

--- a/Quartz/Engine/Include/Quartz/Voxels/CMakeLists.txt
+++ b/Quartz/Engine/Include/Quartz/Voxels/CMakeLists.txt
@@ -2,6 +2,8 @@ set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(voxelHeaders
 	${currentDir}/Block.hpp
 	${currentDir}/Chunk.hpp
+	${currentDir}/ChunkBlockVerts.hpp
+	${currentDir}/ChunkRenderer.hpp
 	${currentDir}/ChunkManager.hpp
 	${currentDir}/Terrain/ITerrainGenerator.hpp
 	${currentDir}/Terrain/PerlinNoise.hpp

--- a/Quartz/Engine/Include/Quartz/Voxels/Chunk.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/Chunk.hpp
@@ -26,6 +26,7 @@
 #include <Quartz/Core/Math/Math.hpp>
 #include <Quartz/Voxels/Block.hpp>
 #include <Quartz/Voxels/ChunkRenderer.hpp>
+#include <Quartz/Core/Utilities/Threading/SingleWorker.hpp>
 
 #include <vector>
 
@@ -45,18 +46,15 @@ namespace qz
 
 		struct ChunkMesh
 		{
-			std::vector<qz::Vector3> vertices;
-			std::vector<qz::Vector3> normals;
-			std::vector<qz::Vector2> uvs;
-			std::vector<int> texLayers;
+			std::vector<ChunkVert3D> verts;
 
 			gfx::TexCache textureCache;
-			std::size_t currentTexLayer;
+			std::size_t currentTexLayer = 0;
 
 			void reset();
 			std::size_t triangleCount() const;
 
-			ChunkMesh() : currentTexLayer(0) {}
+			ChunkMesh() = default;
 		};
 
 		class Chunk
@@ -98,12 +96,13 @@ namespace qz
 			bool m_needsMeshing = false;
 			bool m_hasBeenMeshed = false;
 
-			ChunkMesh m_mesh;
-
 			std::string m_defaultBlockID;
 			std::vector<BlockInstance> m_chunkBlocks;
 
 			ChunkRenderer m_renderer;
+			ChunkMesh m_mesh;
+
+			utils::threading::SingleWorker m_worker;
 
 		private:
 			void addBlockFace(BlockFace face, qz::Vector3 blockPos, const BlockInstance& block);

--- a/Quartz/Engine/Include/Quartz/Voxels/Chunk.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/Chunk.hpp
@@ -66,7 +66,7 @@ namespace qz
 			Chunk(Chunk&& other) noexcept;
 			Chunk& operator=(Chunk&& other) noexcept;
 
-			Chunk(qz::Vector3 chunkPos, int chunkSize, const std::string& defaultBlockID);
+			Chunk(qz::Vector3 chunkPos, const std::string& defaultBlockID);
 			~Chunk() = default;
 
 			void generateTerrain(unsigned int seed);

--- a/Quartz/Engine/Include/Quartz/Voxels/ChunkBlockVerts.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/ChunkBlockVerts.hpp
@@ -1,0 +1,130 @@
+// Copyright 2019 Genten Studios
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+// following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+// following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+// products derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+// DAMAGE.
+
+#pragma once
+
+#include <Quartz/Core/Math/Math.hpp>
+
+const int ACTUAL_CUBE_SIZE = 2;
+const int NUM_FACES_IN_CUBE = 6;
+const int NUM_VERTS_IN_FACE = 6;
+
+static const qz::Vector3 CUBE_VERTS[] = {
+	// front
+	qz::Vector3(-1.f, -1.f, -1.f),
+	qz::Vector3(1.f, -1.f, -1.f),
+	qz::Vector3(1.f,  1.f, -1.f),
+	qz::Vector3(1.f,  1.f, -1.f),
+	qz::Vector3(-1.f,  1.f, -1.f),
+	qz::Vector3(-1.f, -1.f, -1.f),
+
+	// back
+	qz::Vector3(-1.f, -1.f, 1.f),
+	qz::Vector3(1.f, -1.f, 1.f),
+	qz::Vector3(1.f,  1.f, 1.f),
+	qz::Vector3(1.f,  1.f, 1.f),
+	qz::Vector3(-1.f,  1.f, 1.f),
+	qz::Vector3(-1.f, -1.f, 1.f),
+
+	// left
+	qz::Vector3(-1.f,  1.f,  1.f),
+	qz::Vector3(-1.f,  1.f, -1.f),
+	qz::Vector3(-1.f, -1.f, -1.f),
+	qz::Vector3(-1.f, -1.f, -1.f),
+	qz::Vector3(-1.f, -1.f,  1.f),
+	qz::Vector3(-1.f,  1.f,  1.f),
+
+	// right
+	qz::Vector3(1.f,  1.f,  1.f),
+	qz::Vector3(1.f,  1.f, -1.f),
+	qz::Vector3(1.f, -1.f, -1.f),
+	qz::Vector3(1.f, -1.f, -1.f),
+	qz::Vector3(1.f, -1.f,  1.f),
+	qz::Vector3(1.f,  1.f,  1.f),
+
+	// bottom
+	qz::Vector3(-1.f, -1.f, -1.f),
+	qz::Vector3(1.f, -1.f, -1.f),
+	qz::Vector3(1.f, -1.f,  1.f),
+	qz::Vector3(1.f, -1.f,  1.f),
+	qz::Vector3(-1.f, -1.f,  1.f),
+	qz::Vector3(-1.f, -1.f, -1.f),
+
+	// top
+	qz::Vector3(-1.f,  1.f, -1.f),
+	qz::Vector3(1.f,  1.f, -1.f),
+	qz::Vector3(1.f,  1.f,  1.f),
+	qz::Vector3(1.f,  1.f,  1.f),
+	qz::Vector3(-1.f,  1.f,  1.f),
+	qz::Vector3(-1.f,  1.f, -1.f)
+};
+
+static const qz::Vector2 CUBE_UV[] = {
+	// front north
+	qz::Vector2(-0.f, 1.f),
+	qz::Vector2(-1.f, 1.f),
+	qz::Vector2(-1.f, 0.f),
+	qz::Vector2(-1.f, 0.f),
+	qz::Vector2(-0.f, 0.f),
+	qz::Vector2(-0.f, 1.f),
+
+	// back south
+	qz::Vector2(0.f, 1.f),
+	qz::Vector2(1.f, 1.f),
+	qz::Vector2(1.f, 0.f),
+	qz::Vector2(1.f, 0.f),
+	qz::Vector2(0.f, 0.f),
+	qz::Vector2(0.f, 1.f),
+
+	// left west
+	qz::Vector2(-0.f, 0.f),
+	qz::Vector2(-1.f, 0.f),
+	qz::Vector2(-1.f, 1.f),
+	qz::Vector2(-1.f, 1.f),
+	qz::Vector2(-0.f, 1.f),
+	qz::Vector2(-0.f, 0.f),
+
+	// right east
+	qz::Vector2(0.f, 0.f),
+	qz::Vector2(1.f, 0.f),
+	qz::Vector2(1.f, 1.f),
+	qz::Vector2(1.f, 1.f),
+	qz::Vector2(0.f, 1.f),
+	qz::Vector2(0.f, 0.f),
+
+	// bottom
+	qz::Vector2(0.f, 1.f),
+	qz::Vector2(1.f, 1.f),
+	qz::Vector2(1.f, 0.f),
+	qz::Vector2(1.f, 0.f),
+	qz::Vector2(0.f, 0.f),
+	qz::Vector2(0.f, 1.f),
+
+	// top
+	qz::Vector2(0.f, -1.f),
+	qz::Vector2(1.f, -1.f),
+	qz::Vector2(1.f, -0.f),
+	qz::Vector2(1.f, -0.f),
+	qz::Vector2(0.f, -0.f),
+	qz::Vector2(0.f, -1.f),
+};

--- a/Quartz/Engine/Include/Quartz/Voxels/ChunkManager.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/ChunkManager.hpp
@@ -34,7 +34,7 @@ namespace qz
 		class ChunkManager
 		{
 		public:
-			ChunkManager(const std::string& blockID, int chunkSize, unsigned int seed);
+			ChunkManager(const std::string& blockID, unsigned int seed);
 			ChunkManager(ChunkManager&& other) = default;
 
 			~ChunkManager() = default;
@@ -56,7 +56,6 @@ namespace qz
 
 		private:
 			unsigned int m_seed;
-			int m_chunkSize;
 			std::string m_defaultBlockID;
 
 			std::vector<Chunk> m_chunks;

--- a/Quartz/Engine/Include/Quartz/Voxels/ChunkRenderer.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/ChunkRenderer.hpp
@@ -23,34 +23,37 @@
 
 #pragma once
 
-#include <Quartz/Core/Math/Math.hpp>
-#include <Quartz/Voxels/Block.hpp>
-
-#include <luamod/luastate.h>
-#include <luamod/function.h>
+#include <Quartz/Core/Graphics/API/IStateManager.hpp>
+#include <Quartz/Core/Graphics/API/IBuffer.hpp>
+#include <Quartz/Core/Graphics/API/ITextureArray.hpp>
 
 namespace qz
 {
 	namespace voxels
 	{
-		class PerlinNoise
+		struct ChunkMesh;
+
+		class ChunkRenderer
 		{
 		public:
-			PerlinNoise();
-			PerlinNoise(unsigned int seed);
-			~PerlinNoise() = default;
+			ChunkRenderer() = default;
+			~ChunkRenderer() = default;
 
-			void generateFor(std::vector<BlockInstance>& blockArray, qz::Vector3 chunkPos);
-			float at(qz::Vector3 pos) const;
-			float atOctave(qz::Vector3 pos, int octaves, float persitance) const;
+			ChunkRenderer(const ChunkRenderer& other);
+			ChunkRenderer& operator=(const ChunkRenderer& other);
+
+			ChunkRenderer(ChunkRenderer&& other) noexcept;
+			ChunkRenderer& operator=(ChunkRenderer&& other) noexcept;
+
+			void updateMesh(const ChunkMesh& mesh, int* bufferCounter);
+			void render() const;
 
 		private:
-			std::vector<int> m_p;
-			lm::LuaState m_lua;
+			std::size_t m_verticesToDraw = 0;
 
-			float fade(float t) const;
-			float grad(int hash, float x, float y, float z) const;
-			float lerp(float t, float a, float b) const;
+			gfx::api::GraphicsResource<gfx::api::IStateManager> m_stateManager = nullptr;
+			gfx::api::GraphicsResource<gfx::api::IBuffer> m_buffer = nullptr;
+			gfx::api::GraphicsResource<gfx::api::ITextureArray> m_textureArray = nullptr;
 		};
 	}
 }

--- a/Quartz/Engine/Include/Quartz/Voxels/ChunkRenderer.hpp
+++ b/Quartz/Engine/Include/Quartz/Voxels/ChunkRenderer.hpp
@@ -45,7 +45,7 @@ namespace qz
 			ChunkRenderer(ChunkRenderer&& other) noexcept;
 			ChunkRenderer& operator=(ChunkRenderer&& other) noexcept;
 
-			void updateMesh(const ChunkMesh& mesh, int* bufferCounter);
+			bool updateMesh(const ChunkMesh& mesh, int* bufferCounter);
 			void render() const;
 
 		private:

--- a/Quartz/Engine/Source/Core/Graphics/API/GL/GLTextureArray.cpp
+++ b/Quartz/Engine/Source/Core/Graphics/API/GL/GLTextureArray.cpp
@@ -115,30 +115,27 @@ void GLTextureArray::add(const TexCache& cache)
 
 	for (const auto& current : cache)
 	{
-		if (m_texNames.find(current.first) == m_texNames.end())
+		int width = -1, height = -1, nbChannels = -1;
+		unsigned char* image = stbi_load(current.first.c_str(), &width, &height, &nbChannels, 0);
+		if (image != nullptr)
 		{
-			int width = -1, height = -1, nbChannels = -1;
-			unsigned char* image = stbi_load(current.first.c_str(), &width, &height, &nbChannels, 0);
-			if (image != nullptr)
-			{
-				GLCheck(glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, current.second, width, height, 1, GL_RGBA, GL_UNSIGNED_BYTE, image));
+			GLCheck(glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, current.second, width, height, 1, GL_RGBA, GL_UNSIGNED_BYTE, image));
 
-				m_texNames[current.first] = current.second;
-			}
-			else
-			{
-				utils::Logger::instance()->log(utils::LogVerbosity::WARNING, __FILE__, __LINE__, "[RENDERING][TEXTURING]", "The texture: ", current.first, " could not be found.");
-				return;
-			}
-			stbi_image_free(image);
-
-			GLCheck(glGenerateMipmap(GL_TEXTURE_2D_ARRAY));
-			GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR));
-			GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-			GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_REPEAT));
-			GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_REPEAT));
-			GLCheck(glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 16.0f));
+			m_texNames[current.first] = current.second;
 		}
+		else
+		{
+			utils::Logger::instance()->log(utils::LogVerbosity::WARNING, __FILE__, __LINE__, "[RENDERING][TEXTURING]", "The texture: ", current.first, " could not be found.");
+			return;
+		}
+		stbi_image_free(image);
+
+		GLCheck(glGenerateMipmap(GL_TEXTURE_2D_ARRAY));
+		GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR));
+		GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+		GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_REPEAT));
+		GLCheck(glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_REPEAT));
+		GLCheck(glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 16.0f));
 	}
 
 	unbind();

--- a/Quartz/Engine/Source/Core/Utilities/CMakeLists.txt
+++ b/Quartz/Engine/Source/Core/Utilities/CMakeLists.txt
@@ -1,5 +1,9 @@
+add_subdirectory(Threading)
+
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(utilitySources
+	${threadingSources}
+
 	${currentDir}/Logger.cpp
 	${currentDir}/FileIO.cpp
 	${currentDir}/Config.cpp

--- a/Quartz/Engine/Source/Core/Utilities/Threading/CMakeLists.txt
+++ b/Quartz/Engine/Source/Core/Utilities/Threading/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(currentDir ${CMAKE_CURRENT_LIST_DIR})
+set(threadingSources
+	${currentDir}/SingleWorker.cpp
+	${currentDir}/ThreadPool.cpp
+	
+	PARENT_SCOPE
+)

--- a/Quartz/Engine/Source/Voxels/CMakeLists.txt
+++ b/Quartz/Engine/Source/Voxels/CMakeLists.txt
@@ -2,6 +2,7 @@ set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(voxelSources
 	${currentDir}/Block.cpp
 	${currentDir}/Chunk.cpp
+	${currentDir}/ChunkRenderer.cpp
 	${currentDir}/ChunkManager.cpp
 
 	${currentDir}/Entities/Item.cpp

--- a/Quartz/Engine/Source/Voxels/Chunk.cpp
+++ b/Quartz/Engine/Source/Voxels/Chunk.cpp
@@ -22,6 +22,7 @@
 // DAMAGE.
 
 #include <Quartz/Core/QuartzPCH.hpp>
+#include <Quartz/Core/Utilities/Logger.hpp>
 #include <Quartz/Core/Graphics/API/BufferLayout.hpp>
 #include <Quartz/Voxels/Chunk.hpp>
 #include <Quartz/Voxels/ChunkBlockVerts.hpp>
@@ -223,8 +224,8 @@ void Chunk::renderBlocks(int* bufferCounter)
 {
 	if (m_hasBeenMeshed)
 	{
-		m_renderer.updateMesh(m_mesh, bufferCounter);
-		m_hasBeenMeshed = false;
+		if (m_renderer.updateMesh(m_mesh, bufferCounter))
+			m_hasBeenMeshed = false;
 	}
 
 	m_renderer.render();

--- a/Quartz/Engine/Source/Voxels/Chunk.cpp
+++ b/Quartz/Engine/Source/Voxels/Chunk.cpp
@@ -33,19 +33,13 @@ using namespace qz;
 
 void ChunkMesh::reset()
 {
-	vertices.clear();
-	vertices.shrink_to_fit();
-
-	uvs.clear();
-	uvs.shrink_to_fit();
-
-	texLayers.clear();
-	texLayers.shrink_to_fit();
+	verts.clear();
+	verts.shrink_to_fit();
 }
 
 std::size_t ChunkMesh::triangleCount() const
 {
-	return vertices.size() / 3;
+	return verts.size() / 3;
 }
 
 Chunk::Chunk(const Chunk& other) : m_needsMeshing(false)
@@ -232,7 +226,7 @@ void Chunk::renderBlocks(int* bufferCounter)
 
 	if (m_needsMeshing)
 	{
-		buildMesh();
+		m_worker.addWork(std::bind(&Chunk::buildMesh, this));
 		m_needsMeshing = false;
 	}
 }
@@ -269,9 +263,7 @@ void Chunk::addBlockFace(BlockFace face, qz::Vector3 blockPos, const BlockInstan
 
 			qz::Vector2 cubeUVs = CUBE_UV[(static_cast<int>(face) * NUM_FACES_IN_CUBE) + i];
 
-			m_mesh.vertices.push_back(blockVertices);
-			m_mesh.uvs.push_back(cubeUVs);
-			m_mesh.texLayers.push_back(texLayer);
+			m_mesh.verts.emplace_back(blockVertices, cubeUVs, texLayer);
 		}
 	}
 }

--- a/Quartz/Engine/Source/Voxels/Chunk.cpp
+++ b/Quartz/Engine/Source/Voxels/Chunk.cpp
@@ -81,17 +81,17 @@ Chunk& Chunk::operator=(Chunk&& other) noexcept
 	return *this;
 }
 
-Chunk::Chunk(qz::Vector3 chunkPos, int chunkSize, const std::string& defaultBlockID)
+Chunk::Chunk(qz::Vector3 chunkPos, const std::string& defaultBlockID)
 {
 	m_chunkPos = chunkPos;
 	m_defaultBlockID = defaultBlockID;
+
+	for (int i = 0; i < CHUNK_WIDTH * CHUNK_HEIGHT * CHUNK_DEPTH; ++i)
+		m_chunkBlocks.emplace_back(m_defaultBlockID);
 }
 
 void Chunk::generateTerrain(unsigned int seed)
 {
-	for (int i = 0; i < CHUNK_WIDTH * CHUNK_HEIGHT * CHUNK_DEPTH; ++i)
-		m_chunkBlocks.emplace_back(m_defaultBlockID);
-
 	PerlinNoise* terrainGenerator = new PerlinNoise(seed);
 	terrainGenerator->generateFor(m_chunkBlocks, m_chunkPos);
 	delete terrainGenerator;
@@ -103,7 +103,7 @@ void Chunk::buildMesh()
 {
 	std::vector<BlockInstance> blocks = m_chunkBlocks;
 	m_mesh.reset();
-	
+
 	for (int j = CHUNK_WIDTH * CHUNK_HEIGHT * CHUNK_DEPTH; j > 0; --j)
 	{
 		int i = j - 1;

--- a/Quartz/Engine/Source/Voxels/Chunk.cpp
+++ b/Quartz/Engine/Source/Voxels/Chunk.cpp
@@ -353,6 +353,8 @@ void ChunkRenderer::bufferData()
 		temp.emplace_back(m_mesh.vertices[i - 1], m_mesh.uvs[i - 1], m_mesh.texLayers[i - 1]);
 	}
 
+	LDEBUG("Mesh is using: ", sizeof(ChunkVert3D) * m_mesh.vertices.size());
+
 	m_buffer->bind();
 	m_buffer->setData(sizeof(ChunkVert3D) * temp.size(), static_cast<void*>(temp.data()));
 

--- a/Quartz/Engine/Source/Voxels/Chunk.cpp
+++ b/Quartz/Engine/Source/Voxels/Chunk.cpp
@@ -22,387 +22,37 @@
 // DAMAGE.
 
 #include <Quartz/Core/QuartzPCH.hpp>
-#include <Quartz/Voxels/Chunk.hpp>
-		  
 #include <Quartz/Core/Graphics/API/BufferLayout.hpp>
+#include <Quartz/Voxels/Chunk.hpp>
+#include <Quartz/Voxels/ChunkBlockVerts.hpp>
 #include <Quartz/Voxels/Terrain/PerlinNoise.hpp>
-#include <Quartz/Core/Graphics/API/GL/GLCommon.hpp>
 
 using namespace qz::voxels;
 using namespace qz;
 
-static const Vector3 CUBE_VERTS[] = {
-	// front
-	Vector3(-1.f, -1.f, -1.f),
-	Vector3(1.f, -1.f, -1.f),
-	Vector3(1.f,  1.f, -1.f),
-	Vector3(1.f,  1.f, -1.f),
-	Vector3(-1.f,  1.f, -1.f),
-	Vector3(-1.f, -1.f, -1.f),
-
-	// back
-	Vector3(-1.f, -1.f, 1.f),
-	Vector3(1.f, -1.f, 1.f),
-	Vector3(1.f,  1.f, 1.f),
-	Vector3(1.f,  1.f, 1.f),
-	Vector3(-1.f,  1.f, 1.f),
-	Vector3(-1.f, -1.f, 1.f),
-
-	// left
-	Vector3(-1.f,  1.f,  1.f),
-	Vector3(-1.f,  1.f, -1.f),
-	Vector3(-1.f, -1.f, -1.f),
-	Vector3(-1.f, -1.f, -1.f),
-	Vector3(-1.f, -1.f,  1.f),
-	Vector3(-1.f,  1.f,  1.f),
-
-	// right
-	Vector3(1.f,  1.f,  1.f),
-	Vector3(1.f,  1.f, -1.f),
-	Vector3(1.f, -1.f, -1.f),
-	Vector3(1.f, -1.f, -1.f),
-	Vector3(1.f, -1.f,  1.f),
-	Vector3(1.f,  1.f,  1.f),
-
-	// bottom
-	Vector3(-1.f, -1.f, -1.f),
-	Vector3(1.f, -1.f, -1.f),
-	Vector3(1.f, -1.f,  1.f),
-	Vector3(1.f, -1.f,  1.f),
-	Vector3(-1.f, -1.f,  1.f),
-	Vector3(-1.f, -1.f, -1.f),
-
-	// top
-	Vector3(-1.f,  1.f, -1.f),
-	Vector3(1.f,  1.f, -1.f),
-	Vector3(1.f,  1.f,  1.f),
-	Vector3(1.f,  1.f,  1.f),
-	Vector3(-1.f,  1.f,  1.f),
-	Vector3(-1.f,  1.f, -1.f)
-};
-
-static const Vector2 CUBE_UV[] = {
-	// front north
-	Vector2(-0.f, 1.f),
-	Vector2(-1.f, 1.f),
-	Vector2(-1.f, 0.f),
-	Vector2(-1.f, 0.f),
-	Vector2(-0.f, 0.f),
-	Vector2(-0.f, 1.f),
-
-	// back south
-	Vector2(0.f, 1.f),
-	Vector2(1.f, 1.f),
-	Vector2(1.f, 0.f),
-	Vector2(1.f, 0.f),
-	Vector2(0.f, 0.f),
-	Vector2(0.f, 1.f),
-
-	// left west
-	Vector2(-0.f, 0.f),
-	Vector2(-1.f, 0.f),
-	Vector2(-1.f, 1.f),
-	Vector2(-1.f, 1.f),
-	Vector2(-0.f, 1.f),
-	Vector2(-0.f, 0.f),
-
-	// right east
-	Vector2(0.f, 0.f),
-	Vector2(1.f, 0.f),
-	Vector2(1.f, 1.f),
-	Vector2(1.f, 1.f),
-	Vector2(0.f, 1.f),
-	Vector2(0.f, 0.f),
-
-	// bottom
-	Vector2(0.f, 1.f),
-	Vector2(1.f, 1.f),
-	Vector2(1.f, 0.f),
-	Vector2(1.f, 0.f),
-	Vector2(0.f, 0.f),
-	Vector2(0.f, 1.f),
-
-	// top
-	Vector2(0.f, -1.f),
-	Vector2(1.f, -1.f),
-	Vector2(1.f, -0.f),
-	Vector2(1.f, -0.f),
-	Vector2(0.f, -0.f),
-	Vector2(0.f, -1.f),
-};
-
-const int ACTUAL_CUBE_SIZE = 2;
-const int NUM_FACES_IN_CUBE = 6;
-const int NUM_VERTS_IN_FACE = 6;
-
-struct ChunkVert3D
-{
-	qz::Vector3 verts;
-	qz::Vector2 uvs;
-
-	int texLayer;
-
-	ChunkVert3D(const qz::Vector3& vertices, const qz::Vector2& UVs, const int textureLayer) :
-		verts(vertices), uvs(UVs), texLayer(textureLayer)
-	{}
-};
-
-void Mesh::reset()
+void ChunkMesh::reset()
 {
 	vertices.clear();
 	vertices.shrink_to_fit();
-
-	normals.clear();
-	normals.shrink_to_fit();
 
 	uvs.clear();
 	uvs.shrink_to_fit();
 
 	texLayers.clear();
-	uvs.shrink_to_fit();
+	texLayers.shrink_to_fit();
 }
 
-void Mesh::update(const Mesh& other)
-{
-	vertices = other.vertices;
-	normals = other.normals;
-	uvs = other.uvs;
-	texLayers = other.texLayers;
-}
-
-std::size_t Mesh::triangleCount() const
+std::size_t ChunkMesh::triangleCount() const
 {
 	return vertices.size() / 3;
 }
 
-ChunkMesh::ChunkMesh(const ChunkMesh& other)
-{
-	m_blockMesh = other.m_blockMesh;
-	m_objectMesh = other.m_objectMesh;
-	m_waterMesh = other.m_waterMesh;
-}
-
-ChunkMesh& ChunkMesh::operator=(const ChunkMesh& other) = default;
-
-ChunkMesh::ChunkMesh(ChunkMesh&& other)
-{
-	m_blockMesh = std::move(other.m_blockMesh);
-	m_objectMesh = std::move(other.m_objectMesh);
-	m_waterMesh = std::move(other.m_waterMesh);
-}
-
-ChunkMesh& ChunkMesh::operator=(ChunkMesh&& other)
-{
-	m_blockMesh = std::move(other.m_blockMesh);
-	m_objectMesh = std::move(other.m_objectMesh);
-	m_waterMesh = std::move(other.m_waterMesh);
-
-	return *this;
-}
-
-void ChunkMesh::add(const BlockInstance& block, BlockFace face, qz::Vector3 chunkPos, qz::Vector3 blockPos, Chunk* chunk)
-{
-	if (block.getBlockType() == BlockType::SOLID)
-	{
-		ChunkRenderer& renderer = chunk->getBlockRenderer();
-		
-		int texLayer = -1;
-
-		auto& blockTexList = block.getBlockTextures();
-
-		if (static_cast<std::size_t>(face) < blockTexList.size())
-		{
-			renderer.reserveTexture(blockTexList[static_cast<int>(face)]);
-			texLayer = renderer.getTexLayer(blockTexList[static_cast<int>(face)]);
-		}
-
-		for (int i = 0; i < NUM_VERTS_IN_FACE; ++i)
-		{
-			qz::Vector3 blockVertices = CUBE_VERTS[(static_cast<int>(face) * NUM_FACES_IN_CUBE) + i];
-			blockVertices.x += (blockPos.x * ACTUAL_CUBE_SIZE) + (chunkPos.x * ACTUAL_CUBE_SIZE); // Multiply by 2, as that is the size of the actual cube edges, indicated by the cube vertices.
-			blockVertices.y += (blockPos.y * ACTUAL_CUBE_SIZE) + (chunkPos.y * ACTUAL_CUBE_SIZE);
-			blockVertices.z += (blockPos.z * ACTUAL_CUBE_SIZE) + (chunkPos.z * ACTUAL_CUBE_SIZE);
-
-			qz::Vector2 cubeUVs = CUBE_UV[(static_cast<int>(face) * NUM_FACES_IN_CUBE) + i];
-
-			m_blockMesh.vertices.push_back(blockVertices);
-			m_blockMesh.uvs.push_back(cubeUVs);
-			m_blockMesh.texLayers.push_back(texLayer);
-		}
-	}
-}
-
-const Mesh& ChunkMesh::getBlockMesh() const
-{
-	return m_blockMesh;
-}
-
-const Mesh& ChunkMesh::getObjectMesh() const
-{
-	return m_objectMesh;
-}
-
-const Mesh& ChunkMesh::getWaterMesh() const
-{
-	return m_waterMesh;
-}
-
-void ChunkMesh::resetAll()
-{
-	m_blockMesh.reset();
-	m_objectMesh.reset();
-	m_waterMesh.reset();
-}
-
-ChunkRenderer::ChunkRenderer() {}
-ChunkRenderer::~ChunkRenderer() {}
-
-ChunkRenderer::ChunkRenderer(const ChunkRenderer& other)
-{
-	m_mesh = other.m_mesh;
-}
-
-ChunkRenderer& ChunkRenderer::operator=(const ChunkRenderer& other)
-{
-	m_mesh = other.m_mesh;
-
-	m_stateManager = nullptr;
-	m_buffer = nullptr;
-	m_textureArray = nullptr;
-
-	return *this;
-}
-
-ChunkRenderer::ChunkRenderer(ChunkRenderer&& other)
-{
-	m_mesh = std::move(other.m_mesh);
-
-	m_stateManager = nullptr;
-	m_buffer = nullptr;
-
-	std::swap(m_textureArray, other.m_textureArray);
-}
-
-ChunkRenderer& ChunkRenderer::operator=(ChunkRenderer&& other)
-{
-	m_mesh = std::move(other.m_mesh);
-
-	std::swap(m_textureArray, other.m_textureArray);
-
-	return *this;
-}
-
-void ChunkRenderer::resetMesh()
-{
-	m_mesh.reset();
-}
-
-void ChunkRenderer::updateMesh(const Mesh& mesh)
-{
-	m_mesh.update(mesh);
-}
-
-void ChunkRenderer::reserveTexture(const std::string& path)
-{
-	if (m_texReservations.find(path) == m_texReservations.end())
-	{
-		m_texReservations.emplace(path, m_currentLayer);
-		m_currentLayer++;
-	}
-}
-
-int ChunkRenderer::getTexLayer(const std::string& path)
-{
-	const auto it = m_texReservations.find(path);
-
-	if (it == m_texReservations.end())
-	{
-		return m_textureArray->getTexLayer(path);
-	}
-
-	return it->second;
-}
-
-void ChunkRenderer::loadTextures()
-{
-	if (m_textureArray == nullptr)
-		m_textureArray = gfx::api::ITextureArray::generateTextureArray();
-
-	m_textureArray->add(m_texReservations);
-}
-
-void ChunkRenderer::bufferData()
-{
-	if (m_mesh.vertices.empty())
-		return;
-
-	if (m_stateManager == nullptr)
-		m_stateManager = gfx::api::IStateManager::generateStateManager();
-
-	m_stateManager->bind();
-
-	if (m_buffer == nullptr)
-		m_buffer = gfx::api::IBuffer::generateBuffer(gfx::api::BufferTarget::ARRAY_BUFFER, gfx::api::BufferUsage::DYNAMIC);
-
-	std::vector<ChunkVert3D> temp;
-
-	// Not doing vector::size() - 1, i >= 0; as std::size_t is a variant of an unsigned int, which does not go below 0, making it an infinitely running loop. 
-	// (i mean, shit would DEFINITELY hit the ceiling first, but who even fucking cares)
-	for (std::size_t i = m_mesh.vertices.size(); i > 0; i--)
-	{
-		temp.emplace_back(m_mesh.vertices[i - 1], m_mesh.uvs[i - 1], m_mesh.texLayers[i - 1]);
-	}
-
-	LDEBUG("Mesh is using: ", sizeof(ChunkVert3D) * m_mesh.vertices.size());
-
-	m_buffer->bind();
-	m_buffer->setData(sizeof(ChunkVert3D) * temp.size(), static_cast<void*>(temp.data()));
-
-	m_stateManager->attachBuffer(m_buffer);
-
-	gfx::api::BufferLayout bufferLayout;
-
-	bufferLayout.registerAttribute(0, qz::gfx::DataType::FLOAT, 3, sizeof(ChunkVert3D), offsetof(ChunkVert3D, verts), false);
-	bufferLayout.registerAttribute(1, qz::gfx::DataType::FLOAT, 2, sizeof(ChunkVert3D), offsetof(ChunkVert3D, uvs), false);
-	bufferLayout.registerAttribute(2, qz::gfx::DataType::FLOAT, 1, sizeof(ChunkVert3D), offsetof(ChunkVert3D, texLayer), false);
-
-	m_stateManager->attachBufferLayout(bufferLayout);
-
-	m_stateManager->unbind();
-
-	// bufferData() is usually called just before a render call, meaning that if the textureArray is a nullptr, then things will go south pretty fucking fast.
-	if (m_textureArray == nullptr)
-		m_textureArray = gfx::api::ITextureArray::generateTextureArray();
-}
-
-void ChunkRenderer::render() const
-{
-	if (m_mesh.vertices.empty())
-		return;
-
-	m_textureArray->bind(10);
-	m_stateManager->bind();
-	GLCheck(glDrawArrays(GL_TRIANGLES, 0, m_mesh.vertices.size()));
-}
-
-std::size_t ChunkRenderer::getTrianglesCount() const
-{
-	return m_mesh.triangleCount();
-}
-
-Chunk::Chunk(const Chunk& other) : m_chunkFlags(NEEDS_MESHING)
+Chunk::Chunk(const Chunk& other) : m_needsMeshing(false)
 {
 	m_chunkPos = other.m_chunkPos;
-	m_chunkSize = other.m_chunkSize;
-
-	m_mesh = other.m_mesh;
-
-	m_blockRenderer = ChunkRenderer();
-	m_objectRenderer = ChunkRenderer();
-	m_waterRenderer = ChunkRenderer();
-
 	m_defaultBlockID = other.m_defaultBlockID;
 	m_chunkBlocks = other.m_chunkBlocks;
+	m_needsMeshing = other.m_needsMeshing;
 }
 
 Chunk& Chunk::operator=(const Chunk& other)
@@ -411,53 +61,27 @@ Chunk& Chunk::operator=(const Chunk& other)
 		return *this;
 
 	m_chunkPos = other.m_chunkPos;
-	m_chunkSize = other.m_chunkSize;
-
-	m_mesh = other.m_mesh;
-
-	m_blockRenderer = ChunkRenderer();
-	m_objectRenderer = ChunkRenderer();
-	m_waterRenderer = ChunkRenderer();
-
 	m_defaultBlockID = other.m_defaultBlockID;
 	m_chunkBlocks = other.m_chunkBlocks;
+	m_needsMeshing = other.m_needsMeshing;
 
 	return *this;
 }
 
-Chunk::Chunk(Chunk&& other)
+Chunk::Chunk(Chunk&& other) noexcept
 {
 	m_chunkPos = other.m_chunkPos;
-	m_chunkSize = other.m_chunkSize;
-
-	m_mesh = std::move(other.m_mesh);
-
-	m_blockRenderer = std::move(other.m_blockRenderer);
-	m_objectRenderer = std::move(other.m_objectRenderer);
-	m_waterRenderer = std::move(other.m_waterRenderer);
-
-	m_chunkFlags = NEEDS_MESHING;
-
 	m_defaultBlockID = std::move(other.m_defaultBlockID);
 	m_chunkBlocks = std::move(other.m_chunkBlocks);
+	m_needsMeshing = other.m_needsMeshing;
 }
 
-Chunk& Chunk::operator=(Chunk&& other)
+Chunk& Chunk::operator=(Chunk&& other) noexcept
 {
 	m_chunkPos = other.m_chunkPos;
-	m_chunkSize = other.m_chunkSize;
-
-	m_mesh = std::move(other.m_mesh);
-
-	m_blockRenderer = std::move(other.m_blockRenderer);
-	m_objectRenderer = std::move(other.m_objectRenderer);
-	m_waterRenderer = std::move(other.m_waterRenderer);
-
-	m_chunkFlags = NEEDS_MESHING;
-
 	m_defaultBlockID = std::move(other.m_defaultBlockID);
-
 	m_chunkBlocks = std::move(other.m_chunkBlocks);
+	m_needsMeshing = other.m_needsMeshing;
 
 	return *this;
 }
@@ -465,73 +89,55 @@ Chunk& Chunk::operator=(Chunk&& other)
 Chunk::Chunk(qz::Vector3 chunkPos, int chunkSize, const std::string& defaultBlockID)
 {
 	m_chunkPos = chunkPos;
-	m_chunkSize = chunkSize;
 	m_defaultBlockID = defaultBlockID;
-
-	m_chunkFlags = 0;
 }
 
-void Chunk::populateData(unsigned int seed)
+void Chunk::generateTerrain(unsigned int seed)
 {
-	for (std::size_t i = 0; i < m_chunkSize * m_chunkSize * m_chunkSize; ++i)
+	for (int i = 0; i < CHUNK_WIDTH * CHUNK_HEIGHT * CHUNK_DEPTH; ++i)
 		m_chunkBlocks.emplace_back(m_defaultBlockID);
 
 	PerlinNoise* terrainGenerator = new PerlinNoise(seed);
-	terrainGenerator->generateFor(m_chunkBlocks, m_chunkPos, m_chunkSize);
+	terrainGenerator->generateFor(m_chunkBlocks, m_chunkPos);
 	delete terrainGenerator;
 
-	if (!(m_chunkFlags & NEEDS_MESHING))
-		m_chunkFlags |= NEEDS_MESHING;
+	m_needsMeshing = true;
 }
 
 void Chunk::buildMesh()
 {
-	m_mesh.resetAll();
+	std::vector<BlockInstance> blocks = m_chunkBlocks;
+	m_mesh.reset();
 	
-	for (std::size_t j = m_chunkSize * m_chunkSize * m_chunkSize; j > 0; --j)
+	for (int j = CHUNK_WIDTH * CHUNK_HEIGHT * CHUNK_DEPTH; j > 0; --j)
 	{
-		std::size_t i = j - 1;
-		BlockInstance& block = m_chunkBlocks[i];
+		int i = j - 1;
+		BlockInstance& block = blocks[i];
 
 		if (block.getBlockType() == BlockType::GAS)
 			continue;
 
-		const int x = i % m_chunkSize;
-		const int y = (i / m_chunkSize) % m_chunkSize;
-		const int z = i / (m_chunkSize * m_chunkSize);
+		const int x = i % CHUNK_WIDTH;
+		const int y = (i / CHUNK_WIDTH) % CHUNK_HEIGHT;
+		const int z = i / (CHUNK_WIDTH * CHUNK_HEIGHT);
 
 		if (x == 0 || m_chunkBlocks[getVectorIndex(x - 1, y, z)].getBlockType() != BlockType::SOLID)
-			m_mesh.add(block, BlockFace::RIGHT, m_chunkPos, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, this);
-		if (x == m_chunkSize - 1 || m_chunkBlocks[getVectorIndex(x + 1, y, z)].getBlockType() != BlockType::SOLID)
-			m_mesh.add(block, BlockFace::LEFT, m_chunkPos, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, this);
+			addBlockFace(BlockFace::RIGHT, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, block);
+		if (x == CHUNK_WIDTH - 1 || m_chunkBlocks[getVectorIndex(x + 1, y, z)].getBlockType() != BlockType::SOLID)
+			addBlockFace(BlockFace::LEFT, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, block);
 
 		if (y == 0 || m_chunkBlocks[getVectorIndex(x, y - 1, z)].getBlockType() != BlockType::SOLID)
-			m_mesh.add(block, BlockFace::BOTTOM, m_chunkPos, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, this);
-		if (y == m_chunkSize - 1 || m_chunkBlocks[getVectorIndex(x, y + 1, z)].getBlockType() != BlockType::SOLID)
-			m_mesh.add(block, BlockFace::TOP, m_chunkPos, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, this);
+			addBlockFace(BlockFace::BOTTOM, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, block);
+		if (y == CHUNK_HEIGHT - 1 || m_chunkBlocks[getVectorIndex(x, y + 1, z)].getBlockType() != BlockType::SOLID)
+			addBlockFace(BlockFace::TOP, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, block);
 
 		if (z == 0 || m_chunkBlocks[getVectorIndex(x, y, z - 1)].getBlockType() != BlockType::SOLID)
-			m_mesh.add(block, BlockFace::FRONT, m_chunkPos, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, this);
-		if (z == m_chunkSize - 1 || m_chunkBlocks[getVectorIndex(x, y, z + 1)].getBlockType() != BlockType::SOLID)
-			m_mesh.add(block, BlockFace::BACK, m_chunkPos, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, this);
-
+			addBlockFace(BlockFace::FRONT, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, block);
+		if (z == CHUNK_DEPTH - 1 || m_chunkBlocks[getVectorIndex(x, y, z + 1)].getBlockType() != BlockType::SOLID)
+			addBlockFace(BlockFace::BACK, { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) }, block);
 	}
 
-	if (!(m_chunkFlags & BLOCKS_NEED_BUFFERING))
-		m_chunkFlags |= BLOCKS_NEED_BUFFERING;
-
-	if (!(m_chunkFlags & BLOCKS_NEED_TEXTURING))
-		m_chunkFlags |= BLOCKS_NEED_TEXTURING;
-
-	m_chunkFlags &= ~NEEDS_MESHING;
-
-	m_blockRenderer.resetMesh();
-	m_blockRenderer.updateMesh(m_mesh.getBlockMesh());
-}
-
-const ChunkMesh& Chunk::getChunkMesh() const
-{
-	return m_mesh;
+	m_hasBeenMeshed = true;
 }
 
 const Vector3& Chunk::getChunkPos() const
@@ -541,11 +147,11 @@ const Vector3& Chunk::getChunkPos() const
 
 void Chunk::breakBlockAt(qz::Vector3 position, const BlockInstance& block)
 {
-	if (position.x < m_chunkSize)
+	if (position.x < CHUNK_WIDTH)
 	{
-		if (position.y < m_chunkSize)
+		if (position.y < CHUNK_HEIGHT)
 		{
-			if (position.z < m_chunkSize)
+			if (position.z < CHUNK_DEPTH)
 			{
 				BlockInstance& orig = m_chunkBlocks[getVectorIndex(static_cast<int>(position.x), static_cast<int>(position.y), static_cast<int>(position.z))];
 
@@ -555,8 +161,7 @@ void Chunk::breakBlockAt(qz::Vector3 position, const BlockInstance& block)
 
 				orig = block;
 
-				if (!(m_chunkFlags & NEEDS_MESHING))
-					m_chunkFlags |= NEEDS_MESHING;
+				m_needsMeshing = true;
 			}
 		}
 	}
@@ -564,11 +169,11 @@ void Chunk::breakBlockAt(qz::Vector3 position, const BlockInstance& block)
 
 void Chunk::placeBlockAt(qz::Vector3 position, const BlockInstance& block)
 {
-	if (position.x < m_chunkSize)
+	if (position.x < CHUNK_WIDTH)
 	{
-		if (position.y < m_chunkSize)
+		if (position.y < CHUNK_HEIGHT)
 		{
-			if (position.z < m_chunkSize)
+			if (position.z < CHUNK_DEPTH)
 			{
 				auto& placeCallback = BlockLibrary::get()->requestBlock(block.getBlockID()).getPlaceCallback();
 				if (placeCallback != nullptr)
@@ -576,8 +181,7 @@ void Chunk::placeBlockAt(qz::Vector3 position, const BlockInstance& block)
 
 				m_chunkBlocks[getVectorIndex(static_cast<int>(position.x), static_cast<int>(position.y), static_cast<int>(position.z))] = block;
 
-				if (!(m_chunkFlags & NEEDS_MESHING))
-					m_chunkFlags |= NEEDS_MESHING;
+				m_needsMeshing = true;
 			}
 		}
 	}
@@ -585,11 +189,11 @@ void Chunk::placeBlockAt(qz::Vector3 position, const BlockInstance& block)
 
 BlockInstance Chunk::getBlockAt(qz::Vector3 position) const
 {
-	if (position.x < m_chunkSize)
+	if (position.x < CHUNK_WIDTH)
 	{
-		if (position.y < m_chunkSize)
+		if (position.y < CHUNK_HEIGHT)
 		{
-			if (position.z < m_chunkSize)
+			if (position.z < CHUNK_DEPTH)
 			{
 				return m_chunkBlocks[getVectorIndex(static_cast<int>(position.x), static_cast<int>(position.y), static_cast<int>(position.z))];
 			}
@@ -601,81 +205,72 @@ BlockInstance Chunk::getBlockAt(qz::Vector3 position) const
 
 void Chunk::setBlockAt(qz::Vector3 position, const BlockInstance& newBlock)
 {
-	if (position.x < m_chunkSize)
+	if (position.x < CHUNK_WIDTH)
 	{
-		if (position.y < m_chunkSize)
+		if (position.y < CHUNK_HEIGHT)
 		{
-			if (position.z < m_chunkSize)
+			if (position.z < CHUNK_DEPTH)
 			{
 				m_chunkBlocks[getVectorIndex(static_cast<int>(position.x), static_cast<int>(position.y), static_cast<int>(position.z))] = newBlock;
 
-				if (!(m_chunkFlags & NEEDS_MESHING))
-					m_chunkFlags |= NEEDS_MESHING;
+				m_needsMeshing = true;
 			}
 		}
 	}
 }
 
-ChunkRenderer& Chunk::getBlockRenderer()
+void Chunk::renderBlocks(int* bufferCounter)
 {
-	return m_blockRenderer;
-}
-
-ChunkRenderer& Chunk::getObjectRenderer()
-{
-	return m_objectRenderer;
-}
-
-ChunkRenderer& Chunk::getWaterRenderer()
-{
-	return m_waterRenderer;
-}
-
-void Chunk::renderBlocks(int* counter)
-{
-	if (m_chunkFlags & BLOCKS_NEED_BUFFERING)
+	if (m_hasBeenMeshed)
 	{
-		if (*counter > 0)
-			(*counter)--;
-		else
-			return;
-
-		m_blockRenderer.bufferData();
-		m_chunkFlags &= ~BLOCKS_NEED_BUFFERING;
+		m_renderer.updateMesh(m_mesh, bufferCounter);
+		m_hasBeenMeshed = false;
 	}
 
-	if (m_chunkFlags & BLOCKS_NEED_TEXTURING)
+	m_renderer.render();
+
+	if (m_needsMeshing)
 	{
-		if (*counter > 0)
-			(*counter)--;
-		else
-			return;
-
-		m_blockRenderer.loadTextures();
-		m_chunkFlags &= ~BLOCKS_NEED_TEXTURING;
-	}
-
-	m_blockRenderer.render();
-
-	if (m_chunkFlags & NEEDS_MESHING)
-	{
-		if (*counter > 0)
-			(*counter)--;
-		else
-			return;
-
 		buildMesh();
-		m_chunkFlags &= ~NEEDS_MESHING;
+		m_needsMeshing = false;
 	}
 }
 
-void Chunk::renderObjects(int* counter)
+void Chunk::addBlockFace(BlockFace face, qz::Vector3 blockPos, const BlockInstance& block)
 {
-	// TODO: Write function for rendering objects. (TO BE DONE ONCE WE ACTUALLY HAVE OBJECTS)
-}
+	if (block.getBlockType() == BlockType::SOLID)
+	{
+		int texLayer = -1;
 
-void Chunk::renderWater(int* counter)
-{
-	// TODO: Write function for rendering water. (TO BE DONE ONCE WE ACTUALLY HAVE WATER)
-}
+		auto& blockTexList = block.getBlockTextures();
 
+		if (static_cast<std::size_t>(face) < blockTexList.size())
+		{
+			auto it = m_mesh.textureCache.find(blockTexList[static_cast<int>(face)]);
+			if (it == m_mesh.textureCache.end())
+			{
+				m_mesh.textureCache.emplace(blockTexList[static_cast<int>(face)], m_mesh.currentTexLayer);
+				texLayer = m_mesh.currentTexLayer;
+				++m_mesh.currentTexLayer;
+			}
+			else
+			{
+				texLayer = it->second;
+			}
+		}
+
+		for (int i = 0; i < NUM_VERTS_IN_FACE; ++i)
+		{
+			qz::Vector3 blockVertices = CUBE_VERTS[(static_cast<int>(face) * NUM_FACES_IN_CUBE) + i];
+			blockVertices.x += (blockPos.x * ACTUAL_CUBE_SIZE) + (m_chunkPos.x * ACTUAL_CUBE_SIZE); // Multiply by 2, as that is the size of the actual cube edges, indicated by the cube vertices.
+			blockVertices.y += (blockPos.y * ACTUAL_CUBE_SIZE) + (m_chunkPos.y * ACTUAL_CUBE_SIZE);
+			blockVertices.z += (blockPos.z * ACTUAL_CUBE_SIZE) + (m_chunkPos.z * ACTUAL_CUBE_SIZE);
+
+			qz::Vector2 cubeUVs = CUBE_UV[(static_cast<int>(face) * NUM_FACES_IN_CUBE) + i];
+
+			m_mesh.vertices.push_back(blockVertices);
+			m_mesh.uvs.push_back(cubeUVs);
+			m_mesh.texLayers.push_back(texLayer);
+		}
+	}
+}

--- a/Quartz/Engine/Source/Voxels/ChunkManager.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkManager.cpp
@@ -305,7 +305,7 @@ void ChunkManager::placeBlockAt(qz::Vector3 position, const BlockInstance& block
 	}
 }
 
-void ChunkManager::render(int bufferCounter)
+void ChunkManager::render(const int bufferCounter)
 {
 	int count1 = bufferCounter;
 

--- a/Quartz/Engine/Source/Voxels/ChunkManager.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkManager.cpp
@@ -83,7 +83,7 @@ void ChunkManager::determineGeneration(qz::Vector3 cameraPosition)
 				if (result == m_chunks.end())
 				{
 					m_chunks.emplace_back(chunkToCheck, m_chunkSize, m_defaultBlockID);
-					m_chunks.back().populateData(m_seed);
+					m_chunks.back().generateTerrain(m_seed);
 				}
 			}
 		}
@@ -92,12 +92,16 @@ void ChunkManager::determineGeneration(qz::Vector3 cameraPosition)
 
 void ChunkManager::testGeneration()
 {
-	for (int i = 0; i < 5; ++i)
+	for (int i = 0; i < 3; ++i)
 	{
-		qz::Vector3 pain = { i * 16.f, 0, 0 };
+		for (int j = 0; j < 3; ++j)
+		{
+			qz::Vector3 pain = { i * 16.f, 0.f, j * 16.f };
 
-		m_chunks.emplace_back(pain, m_chunkSize, m_defaultBlockID);
-		m_chunks.back().populateData(m_seed);
+			m_chunks.emplace_back(pain, m_chunkSize, m_defaultBlockID);
+			m_chunks.back().generateTerrain(m_seed);
+		}
+
 	}
 }
 
@@ -310,4 +314,3 @@ void ChunkManager::render(int bufferCounter)
 		chunk.renderBlocks(&count1);
 	}
 }
-

--- a/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
@@ -84,7 +84,7 @@ bool ChunkRenderer::updateMesh(const ChunkMesh& mesh, int* bufferCounter)
 	{
 		--(*bufferCounter);
 
-		m_verticesToDraw = mesh.vertices.size();
+		m_verticesToDraw = mesh.verts.size();
 
 		if (m_verticesToDraw == 0)
 			return true;
@@ -97,17 +97,8 @@ bool ChunkRenderer::updateMesh(const ChunkMesh& mesh, int* bufferCounter)
 		if (m_buffer == nullptr)
 			m_buffer = gfx::api::IBuffer::generateBuffer(gfx::api::BufferTarget::ARRAY_BUFFER, gfx::api::BufferUsage::DYNAMIC);
 
-		std::vector<ChunkVert3D> temp;
-
-		// Not doing vector::size() - 1, i >= 0; as std::size_t is a variant of an unsigned int, which does not go below 0, making it an infinitely running loop. 
-		// (i mean, shit would DEFINITELY hit the ceiling first, but who even fucking cares)
-		for (std::size_t i = mesh.vertices.size(); i > 0; i--)
-		{
-			temp.emplace_back(mesh.vertices[i - 1], mesh.uvs[i - 1], mesh.texLayers[i - 1]);
-		}
-
 		m_buffer->bind();
-		m_buffer->setData(sizeof(ChunkVert3D) * temp.size(), static_cast<void*>(temp.data()));
+		m_buffer->setData(sizeof(ChunkVert3D) * mesh.verts.size(), static_cast<const void*>(mesh.verts.data()));
 
 		m_stateManager->attachBuffer(m_buffer);
 

--- a/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
@@ -1,0 +1,147 @@
+// Copyright 2019 Genten Studios
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+// following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+// following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+// products derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+// DAMAGE.
+
+#include <Quartz/Voxels/ChunkRenderer.hpp>
+#include <Quartz/Voxels/Chunk.hpp>
+#include <Quartz/Core/Utilities/Logger.hpp>
+
+using namespace qz::voxels;
+using namespace qz;
+
+struct ChunkVert3D
+{
+	qz::Vector3 verts;
+	qz::Vector2 uvs;
+
+	int texLayer;
+
+	ChunkVert3D(const qz::Vector3& vertices, const qz::Vector2& UVs, const int textureLayer) :
+		verts(vertices), uvs(UVs), texLayer(textureLayer)
+	{}
+};
+
+ChunkRenderer::ChunkRenderer(const ChunkRenderer& other)
+{
+	m_stateManager = other.m_stateManager;
+	m_buffer = other.m_buffer;
+	m_textureArray = other.m_textureArray;
+	m_verticesToDraw = other.m_verticesToDraw;
+}
+
+ChunkRenderer& ChunkRenderer::operator=(const ChunkRenderer& other)
+{
+	m_stateManager = other.m_stateManager;
+	m_buffer = other.m_buffer;
+	m_textureArray = other.m_textureArray;
+	m_verticesToDraw = other.m_verticesToDraw;
+
+	return *this;
+}
+
+ChunkRenderer::ChunkRenderer(ChunkRenderer&& other) noexcept
+{
+	m_stateManager = other.m_stateManager;
+	m_buffer = other.m_buffer;
+	m_textureArray = other.m_textureArray;
+	m_verticesToDraw = other.m_verticesToDraw;
+}
+
+ChunkRenderer& ChunkRenderer::operator=(ChunkRenderer&& other) noexcept
+{
+	m_stateManager = other.m_stateManager;
+	m_buffer = other.m_buffer;
+	m_textureArray = other.m_textureArray;
+	m_verticesToDraw = other.m_verticesToDraw;
+
+	return *this;
+}
+
+void ChunkRenderer::updateMesh(const ChunkMesh& mesh, int* bufferCounter)
+{
+	{
+		if ((*bufferCounter) == 0)
+			return;
+
+		--(*bufferCounter);
+
+		m_verticesToDraw = mesh.vertices.size();
+
+		if (m_verticesToDraw == 0)
+			return;
+
+		if (m_stateManager == nullptr)
+			m_stateManager = gfx::api::IStateManager::generateStateManager();
+
+		m_stateManager->bind();
+
+		if (m_buffer == nullptr)
+			m_buffer = gfx::api::IBuffer::generateBuffer(gfx::api::BufferTarget::ARRAY_BUFFER, gfx::api::BufferUsage::DYNAMIC);
+
+		std::vector<ChunkVert3D> temp;
+
+		// Not doing vector::size() - 1, i >= 0; as std::size_t is a variant of an unsigned int, which does not go below 0, making it an infinitely running loop. 
+		// (i mean, shit would DEFINITELY hit the ceiling first, but who even fucking cares)
+		for (std::size_t i = mesh.vertices.size(); i > 0; i--)
+		{
+			temp.emplace_back(mesh.vertices[i - 1], mesh.uvs[i - 1], mesh.texLayers[i - 1]);
+		}
+
+		m_buffer->bind();
+		m_buffer->setData(sizeof(ChunkVert3D) * temp.size(), static_cast<void*>(temp.data()));
+
+		m_stateManager->attachBuffer(m_buffer);
+
+		gfx::api::BufferLayout bufferLayout;
+
+		bufferLayout.registerAttribute(0, qz::gfx::DataType::FLOAT, 3, sizeof(ChunkVert3D), offsetof(ChunkVert3D, verts), false);
+		bufferLayout.registerAttribute(1, qz::gfx::DataType::FLOAT, 2, sizeof(ChunkVert3D), offsetof(ChunkVert3D, uvs), false);
+		bufferLayout.registerAttribute(2, qz::gfx::DataType::FLOAT, 1, sizeof(ChunkVert3D), offsetof(ChunkVert3D, texLayer), false);
+
+		m_stateManager->attachBufferLayout(bufferLayout);
+
+		m_stateManager->unbind();
+	}
+
+	{
+		if ((*bufferCounter) == 0)
+			return;
+
+		--(*bufferCounter);
+
+		if (m_textureArray == nullptr)
+			m_textureArray = gfx::api::ITextureArray::generateTextureArray();
+
+		if (mesh.textureCache != m_textureArray->getTextureList())
+			m_textureArray->add(mesh.textureCache);
+	}
+}
+
+void ChunkRenderer::render() const
+{
+	if (m_verticesToDraw == 0)
+		return;
+
+	m_textureArray->bind(10);
+	m_stateManager->bind();
+	m_stateManager->render(0, m_verticesToDraw);
+}

--- a/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
@@ -25,6 +25,8 @@
 #include <Quartz/Voxels/Chunk.hpp>
 #include <Quartz/Core/Utilities/Logger.hpp>
 
+#include <cstddef>
+
 using namespace qz::voxels;
 using namespace qz;
 

--- a/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
@@ -28,18 +28,6 @@
 using namespace qz::voxels;
 using namespace qz;
 
-struct ChunkVert3D
-{
-	qz::Vector3 verts;
-	qz::Vector2 uvs;
-
-	int texLayer;
-
-	ChunkVert3D(const qz::Vector3& vertices, const qz::Vector2& UVs, const int textureLayer) :
-		verts(vertices), uvs(UVs), texLayer(textureLayer)
-	{}
-};
-
 ChunkRenderer::ChunkRenderer(const ChunkRenderer& other)
 {
 	m_stateManager = other.m_stateManager;

--- a/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
+++ b/Quartz/Engine/Source/Voxels/ChunkRenderer.cpp
@@ -76,18 +76,18 @@ ChunkRenderer& ChunkRenderer::operator=(ChunkRenderer&& other) noexcept
 	return *this;
 }
 
-void ChunkRenderer::updateMesh(const ChunkMesh& mesh, int* bufferCounter)
+bool ChunkRenderer::updateMesh(const ChunkMesh& mesh, int* bufferCounter)
 {
+	if ((*bufferCounter) < 2)
+		return false;
+	
 	{
-		if ((*bufferCounter) == 0)
-			return;
-
 		--(*bufferCounter);
 
 		m_verticesToDraw = mesh.vertices.size();
 
 		if (m_verticesToDraw == 0)
-			return;
+			return true;
 
 		if (m_stateManager == nullptr)
 			m_stateManager = gfx::api::IStateManager::generateStateManager();
@@ -123,17 +123,17 @@ void ChunkRenderer::updateMesh(const ChunkMesh& mesh, int* bufferCounter)
 	}
 
 	{
-		if ((*bufferCounter) == 0)
-			return;
-
-		--(*bufferCounter);
-
 		if (m_textureArray == nullptr)
 			m_textureArray = gfx::api::ITextureArray::generateTextureArray();
 
 		if (mesh.textureCache != m_textureArray->getTextureList())
+		{
+			--(*bufferCounter);
 			m_textureArray->add(mesh.textureCache);
+		}
 	}
+
+	return true;
 }
 
 void ChunkRenderer::render() const

--- a/QuartzSandbox/Source/Sandbox.cpp
+++ b/QuartzSandbox/Source/Sandbox.cpp
@@ -82,12 +82,6 @@ static void QuickSetupLuaBindingsCommon(lm::LuaState& state)
 
 void Sandbox::run()
 {
-	LDEBUG("One Block is: ", sizeof(qz::voxels::BlockInstance));
-	LDEBUG("SingleWorker is: ", sizeof(qz::utils::threading::SingleWorker));
-	LDEBUG("One Chunk is: ", sizeof(qz::voxels::Chunk));
-	LDEBUG("One ChunkRenderer is: ", sizeof(qz::voxels::ChunkRenderer));
-	LDEBUG("One ChunkMesh is: ", sizeof(qz::voxels::ChunkMesh));
-
 	QZ_REGISTER_CONFIG("Controls");
 
 	gfx::IWindow* window = m_appData->window;
@@ -114,7 +108,7 @@ void Sandbox::run()
 	shader->addStage(ShaderType::FRAGMENT_SHADER, utils::FileIO::readAllFile("assets/shaders/main.frag"));
 	shader->build();
 
-	voxels::ChunkManager* world = new voxels::ChunkManager("core:air", 16, time(nullptr));
+	voxels::ChunkManager* world = new voxels::ChunkManager("core:air", time(nullptr));
 
 	world->testGeneration();
 

--- a/QuartzSandbox/Source/Sandbox.cpp
+++ b/QuartzSandbox/Source/Sandbox.cpp
@@ -94,13 +94,14 @@ void Sandbox::run()
 	using namespace gfx::api;
 	using namespace voxels;
 
+	BlockLibrary::get()->init();
+
 	lm::LuaState luaState;
 	QuickSetupLuaBindingsCommon(luaState);
 	luaState.RunFile("assets/scripts/index.lua");
 
 	RegistryBlock air("core:air", "Air", 100, BlockType::GAS);
 
-	BlockLibrary::get()->init();
 	BlockLibrary::get()->registerBlock(air);
 
 	auto shader = IShaderPipeline::generateShaderPipeline();

--- a/QuartzSandbox/Source/Sandbox.cpp
+++ b/QuartzSandbox/Source/Sandbox.cpp
@@ -82,6 +82,12 @@ static void QuickSetupLuaBindingsCommon(lm::LuaState& state)
 
 void Sandbox::run()
 {
+	LDEBUG("One Block is: ", sizeof(qz::voxels::BlockInstance));
+	LDEBUG("SingleWorker is: ", sizeof(qz::utils::threading::SingleWorker));
+	LDEBUG("One Chunk is: ", sizeof(qz::voxels::Chunk));
+	LDEBUG("One ChunkRenderer is: ", sizeof(qz::voxels::ChunkRenderer));
+	LDEBUG("One ChunkMesh is: ", sizeof(qz::voxels::ChunkMesh));
+
 	QZ_REGISTER_CONFIG("Controls");
 
 	gfx::IWindow* window = m_appData->window;

--- a/QuartzSandbox/Source/Sandbox.cpp
+++ b/QuartzSandbox/Source/Sandbox.cpp
@@ -82,9 +82,6 @@ static void QuickSetupLuaBindingsCommon(lm::LuaState& state)
 
 void Sandbox::run()
 {
-	LDEBUG("Size of a single Block Instance: ", sizeof(qz::voxels::BlockInstance));
-	LDEBUG("Size of 4096 Block Instances: ", sizeof(qz::voxels::BlockInstance) * 4096);
-
 	QZ_REGISTER_CONFIG("Controls");
 
 	gfx::IWindow* window = m_appData->window;

--- a/QuartzSandbox/Source/Sandbox.cpp
+++ b/QuartzSandbox/Source/Sandbox.cpp
@@ -23,14 +23,14 @@
 
 #include <Sandbox/Sandbox.hpp>
 #include <Quartz.hpp>
-
 #include <Quartz/Voxels/ChunkManager.hpp>
 
 #include <luamod/luastate.h>
 #include <luamod/table.h>
-
 #include <glad/glad.h>
 #include <imgui/imgui.h>
+
+#include <ctime>
 
 using namespace sandbox;
 using namespace qz;
@@ -78,11 +78,13 @@ static void QuickSetupLuaBindingsCommon(lm::LuaState& state)
 	};
 
 	state.Register("px_register_block", luaRegisterBlock);
-
 }
 
 void Sandbox::run()
 {
+	LDEBUG("Size of a single Block Instance: ", sizeof(qz::voxels::BlockInstance));
+	LDEBUG("Size of 4096 Block Instances: ", sizeof(qz::voxels::BlockInstance) * 4096);
+
 	QZ_REGISTER_CONFIG("Controls");
 
 	gfx::IWindow* window = m_appData->window;
@@ -111,7 +113,7 @@ void Sandbox::run()
 
 	voxels::ChunkManager* world = new voxels::ChunkManager("core:air", 16, time(nullptr));
 
-	world->determineGeneration(m_camera->getPosition());
+	world->testGeneration();
 
 	const Matrix4x4 model;
 
@@ -146,7 +148,7 @@ void Sandbox::run()
 		shader->setMat4("u_view", m_camera->calculateViewMatrix());
 		shader->setMat4("u_model", model);
 
-		world->render(10);  // should be in the settings (the chunks actualisation factor, here: 10 per frame)
+		world->render(10);  // should be in the settings (the chunks actualization factor, here: 10 per frame)
 
 		ImGui::Begin("Debug Information");
 		ImGui::Text("FPS: %d", fpsCurrent);


### PR DESCRIPTION
## Changelog
- Reduced Memory Overhead in each chunk
  - BlockInstance uses much less memory, allowing the copy of the std::vector storing the block instances to be done quickly, which improves ease of multithreading.
- Each Chunk has it's own thread
  - The thread schedules things like mesh building when necessary.
  - The thread will automatically join and finish all tasks until they're all finished - mainly so std::terminate isn't called and the program doesn't immediately crash.