### PR TITLE
close #116

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ BUILD/*
 Build/*
 **/Quartz/Documentation/html
 **/cmake-build-debug
-
+CMakeFiles/
+CMakeCache.txt
 # CLion
 **/.idea/
 

--- a/Quartz/Engine/Include/Quartz/Core/Graphics/API/GL/GLRenderDevice.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Graphics/API/GL/GLRenderDevice.hpp
@@ -77,7 +77,13 @@ namespace qz
 					virtual void setVertexBufferStream(VertexBufferHandle buffer, int streamId, int stride, int offset);
 
 					virtual void setBufferData(VertexBufferHandle buffer, float *data, std::size_t sizebytes);
-					virtual ShaderPipelineHandle createShaderPipeline(const std::string& shadersource, const InputLayout& inputLayout);
+					
+
+					/**
+					 * @brief			See Core/Graphics/API/IRenderDevice.hpp
+					 */
+					virtual ShaderPipelineHandle createShaderPipelineFromSource(const std::string& dirpath, const std::string& sourcecode, const InputLayout& inputLayout) ;
+					virtual ShaderPipelineHandle createShaderPipelineFromFile(const std::string& filepath, const InputLayout& inputLayout);
 					virtual void setShaderPipeline(ShaderPipelineHandle shader);
 
 					virtual UniformHandle createUniform(ShaderPipelineHandle shaderHandle, const char* name, UniformType type);

--- a/Quartz/Engine/Include/Quartz/Core/Graphics/API/GL/GLShaderPipeline.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Graphics/API/GL/GLShaderPipeline.hpp
@@ -44,7 +44,8 @@ namespace qz
 					InputLayout m_inputLayout;
 
 				public:
-					void create(const std::string& filepath, const InputLayout& inputLayout);
+
+					void create(const std::string & dirpath, const std::string& sourcecode, const InputLayout& inputLayout);
 					void use();
 
 					GLuint getID() const { return m_id; }

--- a/Quartz/Engine/Include/Quartz/Core/Graphics/API/IRenderDevice.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Graphics/API/IRenderDevice.hpp
@@ -55,7 +55,16 @@ namespace qz
 				virtual void setVertexBufferStream(VertexBufferHandle buffer, int streamId, int stride, int offset) = 0;
 				virtual void setBufferData(VertexBufferHandle buffer, float *data, std::size_t sizebytes) = 0;
 				
-				virtual ShaderPipelineHandle createShaderPipeline(const std::string& filepath, const InputLayout& inputLayout) = 0;
+				/**
+				 * @brief			Create shader from source code.
+				 * @param  dirpath	    path to directory used as working directory when parsing the source code. 
+									    ( #include directives will be intepreted relative to this dir )
+				 * @param  sourcecode    The shader source code. Should contain all necessary shader stages.
+				 * @param  inputlayout   Specificy the layout of that data passed into the shader.
+				 * @return Handle to the newly created shader
+				 */
+				virtual ShaderPipelineHandle createShaderPipelineFromSource(const std::string& dirpath, const std::string& sourcecode, const InputLayout& inputLayout) = 0;
+				virtual ShaderPipelineHandle createShaderPipelineFromFile(const std::string& filepath, const InputLayout& inputLayout) = 0;
 				virtual void setShaderPipeline(ShaderPipelineHandle shader) = 0;
 
 				virtual UniformHandle createUniform(ShaderPipelineHandle shader, const char* name, UniformType type) = 0;

--- a/Quartz/Engine/Include/Quartz/Core/Utilities/FileIO.hpp
+++ b/Quartz/Engine/Include/Quartz/Core/Utilities/FileIO.hpp
@@ -41,6 +41,12 @@ namespace qz
 			 * @return A string containing the contents of the file.
 			 */
 			static std::string readAllFile(const std::string& filepath);
+			/**
+			 * @brief Returns the path to the directory containing the file
+			 * @param filepath The path to the file needing to be read.
+			 * @return directory path
+			 */
+			static std::string getDirname(const std::string& filepath);
 		};
 	}
 }

--- a/Quartz/Engine/Source/Core/Graphics/API/GL/GLRenderDevice.cpp
+++ b/Quartz/Engine/Source/Core/Graphics/API/GL/GLRenderDevice.cpp
@@ -1,5 +1,6 @@
 #include <Quartz/Core/Graphics/API/GL/GLRenderDevice.hpp>
 #include <Quartz/Core/Graphics/API/InputLayout.hpp>
+#include <Quartz/Core/Utilities/FileIO.hpp>
 
 #include <imgui/imgui.h>
 #include <cstring>
@@ -57,12 +58,24 @@ VertexBufferHandle GLRenderDevice::createVertexBuffer()
 	return handle;
 }
 
-ShaderPipelineHandle GLRenderDevice::createShaderPipeline(const std::string& shadersource, const InputLayout& inputLayout)
+
+ShaderPipelineHandle GLRenderDevice::createShaderPipelineFromSource(const std::string& dirpath, const std::string& sourcecode, const InputLayout& inputLayout)
 {
 	ShaderPipelineHandle handle = m_shaderHandles.allocate();
-	m_shaders[handle.get()].create(shadersource, inputLayout);
-
+	m_shaders[handle.get()].create(dirpath, sourcecode, inputLayout);
 	return handle;
+}
+ShaderPipelineHandle GLRenderDevice::createShaderPipelineFromFile(const std::string& filepath, const InputLayout& inputLayout)
+{
+	std::string sourcecode = qz::utils::FileIO::readAllFile(filepath);
+	std::string dirname = qz::utils::FileIO::getDirname(filepath);
+	if (sourcecode.size() == 0)
+	{
+		LFATAL("Shader source code error at %d : %d filename %s Not found!", filepath[0]);
+		assert(false);
+		return ShaderPipelineHandle();
+	}
+	return this->createShaderPipelineFromSource(dirname, sourcecode, inputLayout);
 }
 
 void GLRenderDevice::setBufferData(VertexBufferHandle buffer, float *data, std::size_t sizebytes)

--- a/Quartz/Engine/Source/Core/Utilities/FileIO.cpp
+++ b/Quartz/Engine/Source/Core/Utilities/FileIO.cpp
@@ -42,3 +42,8 @@ std::string FileIO::readAllFile(const std::string& filepath)
 	return fileString;
 }
 
+std::string FileIO::getDirname(const std::string& filename)
+{
+	std::size_t p = filename.find_last_of("\\/");
+	return p == std::string::npos ? "" : filename.substr(0, p + 1);
+};

--- a/QuartzSandbox/Source/Sandbox.cpp
+++ b/QuartzSandbox/Source/Sandbox.cpp
@@ -129,8 +129,14 @@ void Sandbox::run()
 
 	VertexBufferHandle topTriangleBuffer = m_renderDevice->createVertexBuffer();
 	m_renderDevice->setBufferData(topTriangleBuffer, topTriangleVertices, sizeof(topTriangleVertices));
-
-	ShaderPipelineHandle shader = m_renderDevice->createShaderPipeline("assets/shaders/basic.shader", layout);
+	const std::string testShaderSource = 
+	R"(#shader frag
+#include "test.frag"
+#shader vertex
+#include "test.vert"
+	)";
+	//ShaderPipelineHandle shader = m_renderDevice->createShaderPipelineFromSource("assets/shaders/tests/", testShaderSource, layout);
+	ShaderPipelineHandle shader = m_renderDevice->createShaderPipelineFromFile("assets/shaders/tests/test.shader", layout);
 	UniformHandle colorHandle = m_renderDevice->createUniform(shader, "u_color", UniformType::COLOR3);
 	UniformHandle samplerUniform = m_renderDevice->createUniform(shader, "u_sampler", UniformType::SAMPLER);
 	int id = 0;

--- a/QuartzSandbox/assets/shaders/tests/test.frag
+++ b/QuartzSandbox/assets/shaders/tests/test.frag
@@ -1,0 +1,13 @@
+#version 330 core
+
+out vec4 FragColor;
+
+in vec2 pass_uv;
+
+uniform vec3 u_color;
+uniform sampler2D u_sampler;
+
+void main()
+{
+	FragColor = texture(u_sampler, pass_uv) * vec4(u_color, 1.0f);
+}

--- a/QuartzSandbox/assets/shaders/tests/test.shader
+++ b/QuartzSandbox/assets/shaders/tests/test.shader
@@ -1,0 +1,4 @@
+#shader pixel
+#include "test.frag"
+#shader vertex
+#include "test.vert"

--- a/QuartzSandbox/assets/shaders/tests/test.vert
+++ b/QuartzSandbox/assets/shaders/tests/test.vert
@@ -1,0 +1,12 @@
+#version 330 core
+
+layout (location = 0) in vec3 a_pos;
+layout(location = 1) in vec2 a_uv;
+
+out vec2 pass_uv;
+
+void main()
+{
+    gl_Position = vec4(a_pos, 1.0);
+	pass_uv = a_uv;
+}


### PR DESCRIPTION
Shader Pipeline creation via file or source, requires a dirpath for include directives : close #116.

Question:
Should all shader source require `#shader` directive to be parsed before the `#include` directive?
It might be useful to be able to parse some shaders as such: 

foo.shader
`#include "foo.frag"`
`#include "foo.vert"`

foo.vert
`#shader vertex`
`...`

foo.frag
`#shader pixel`
`...`

Might create an issue, if it doesn't seem pointless, else will move on to other issues.