### PR TITLE
Remove code that checks for luamod submodule

### DIFF
--- a/Quartz/ThirdParty/CMakeLists.txt
+++ b/Quartz/ThirdParty/CMakeLists.txt
@@ -4,13 +4,6 @@ option(LIBC "..." ON)
 
 project(QuartzDependencies)
 
-if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/luamod/include)
-	message("It seems like the Git Submodules have not been initialised and cloned, they will now be initialised and cloned as required.")
-	execute_process(COMMAND git submodule update --init
-			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	)
-endif()
-
 set(SDL_SHARED_ENABLED_BY_DEFAULT OFF)
 
 add_subdirectory(glad)


### PR DESCRIPTION
There was some code in the external library CMake glue code that would check if the luamod submodule exists, and if not invoke git to init all the submodules automatically.

Since we removed the luamod dependency (and hence all git submodules) we can get rid of this code. It also stops CMake trying to clone submodules that don't exist on configure.