### PR TITLE
Update target C++ standard to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Quartz)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(Quartz)
 add_subdirectory(QuartzSandbox)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(Quartz)
 
-set(CMAKE_CXX_STANDARD 11)
-
-if(UNIX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
+set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(Quartz)
 add_subdirectory(QuartzSandbox)
+


### PR DESCRIPTION
As previously discussed we'll now target C++17 instead of just C++11, so this updates the CMake to reflect that change.

This also gets rid of manually adding `--std=xxxxx` for Unix targets. 

This should not be needed as setting `CMAKE_CXX_STANDARD` should do that for us.
By manually adding `--std=xxxxx` the compiler invocation would probably end up with multiple arguments specifying the language version.