### PR TITLE
Update supported C++ compiler versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 ## Dependencies
 
 - CMake (Version >= 3.0)
-- A C++11 compatible compiler. The following have been tested
-  - Visual Studio 2017 (MSVC 14.10)
-  - Clang/Clang++ (Clang 7.0.0-3)
+- A C++17 compatible compiler. The following have been tested
+  - Visual Studio 2017 & 2019 (MSVC >= 19.14)
+  - Clang (>= 5.0.0)
+  - GCC (>= 4.8.4)
 - OpenGL (Version >= 3.3)
 
 ## Build Instructions


### PR DESCRIPTION
This patch updates the supported C++ version in the README as well as the offically supported compilers

I just got this list from what I regularly use and what the CI covers. If anyone else has a compiler they commonly use for this project, then feel free to make a PR adding that it is supported

For some reason this patch touches all the line endings, I'm guessing as they have got mixed, so this normalises them all to unix line endings.

@apachano adding you on this again as it is documentation related (sorry bout' this!)